### PR TITLE
Change let to var because of backwards compatibility.

### DIFF
--- a/mustuse-loader.php
+++ b/mustuse-loader.php
@@ -287,10 +287,10 @@ class Must_Use_Plugins_Subdir_Loader {
 		?>
 		<script type="text/javascript">
 			jQuery(document).ready(function ($) {
-				let text,
-					value,
-					mustuse,
-					selector;
+				var text;
+				var value;
+				var mustuse;
+				var selector;
 
 				// replace the brackets and set int value
 				selector = '.mustuse span';


### PR DESCRIPTION
I would love to use your package. But because it is only available for ES6 I am not able to use it. If you change it I would happily include your package.