### PR TITLE
Don't load plugins starting with an underscore

### DIFF
--- a/mustuse-loader.php
+++ b/mustuse-loader.php
@@ -217,7 +217,7 @@ class Must_Use_Plugins_Subdir_Loader {
 		foreach ( $mu_plugins as $plugin_file => $not_used ) {
 			// Skip files directly at root
 			// And skip folders starting with an underscore as we want to turn those plugins off.
-			if ( '.' !== dirname( $plugin_file ) && substr(dirname( $plugin_file ), 0, 1) !== '_') {
+			if ( '.' !== dirname( $plugin_file ) && substr( dirname( $plugin_file ), 0, 1 ) !== '_') {
 				$plugins[] = $plugin_file;
 			}
 		}

--- a/mustuse-loader.php
+++ b/mustuse-loader.php
@@ -217,7 +217,7 @@ class Must_Use_Plugins_Subdir_Loader {
 		foreach ( $mu_plugins as $plugin_file => $not_used ) {
 			// Skip files directly at root
 			// And skip folders starting with an underscore as we want to turn those plugins off.
-			if ( '.' !== dirname( $plugin_file ) && substr( dirname( $plugin_file ), 0, 1 ) !== '_') {
+			if ( '.' !== dirname( $plugin_file ) && substr( dirname( $plugin_file ), 0, 1 ) !== '_' ) {
 				$plugins[] = $plugin_file;
 			}
 		}

--- a/mustuse-loader.php
+++ b/mustuse-loader.php
@@ -215,8 +215,9 @@ class Must_Use_Plugins_Subdir_Loader {
 
 		// The function array_keys() is ugly and a performance impact.
 		foreach ( $mu_plugins as $plugin_file => $not_used ) {
-			// skip files directly at root
-			if ( '.' !== dirname( $plugin_file ) ) {
+			// Skip files directly at root
+			// And skip folders starting with an underscore as we want to turn those plugins off.
+			if ( '.' !== dirname( $plugin_file ) && substr(dirname( $plugin_file ), 0, 1) !== '_') {
 				$plugins[] = $plugin_file;
 			}
 		}

--- a/readme.md
+++ b/readme.md
@@ -17,6 +17,14 @@ The plugin have a simple cache and you flush this cache if you go to the network
  3. Alternative define your Must Use folder in the `wp-config.php` and copy the plugin in this folder
  4. Check in the network plugin page, if it works
 
+### Alternative via Composer
+
+To install the package via composer
+
+```bash
+composer require "bueltge/must-use-loader"
+```
+
 #### Alternative via Git
  1. Go to your Must Use folder `cd path`
  2. `git init .`


### PR DESCRIPTION
To keep the ability to turn them off in case of debugging or bugs on critical environments.