### PR TITLE
Add a check that prevents mu-plugins-loader to load before WordPress …

### DIFF
--- a/mustuse-loader.php
+++ b/mustuse-loader.php
@@ -30,6 +30,10 @@ if ( ! function_exists( 'add_filter' ) ) {
 	exit();
 }
 
+if(!is_blog_installed()) {
+	return;
+}
+
 add_action(
 	'muplugins_loaded',
 	[ Must_Use_Plugins_Subdir_Loader::get_instance(), 'plugin_setup' ]

--- a/mustuse-loader.php
+++ b/mustuse-loader.php
@@ -30,8 +30,8 @@ if ( ! function_exists( 'add_filter' ) ) {
 	exit();
 }
 
-if(!is_blog_installed()) {
-	return;
+if ( ! is_blog_installed() ) {
+ 	return;
 }
 
 add_action(


### PR DESCRIPTION
…is installed.

The problem is that `set_site_transient()` already tries to insert into the DB before we can even install WordPress.

This causes an notice which, later on, causes a headers already sent warning.

To prevent this from happening, we add a check before we run the mu-plugins.