### PR TITLE
fix 1.3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,10 @@
     }
   ],
   "require": {
-    "php": ">=5.6",
+    "php": ">=5.6"
+
+  },
+  "require-dev": {
     "inpsyde/php-coding-standards": "dev-master"
   }
 }

--- a/must_use_loader.php
+++ b/must_use_loader.php
@@ -7,7 +7,7 @@
  *   from Must Use plugin folder
  * Plugin Name: Must-Use Loader
  * Plugin URI:  https://github.com/bueltge/must-use-loader
- * Description: Load Must-Use Plugins inside subdirectories with caching. For delete the cache: if you view the Must Use plugin list in the network administration.
+ * Description: Load Must-Use Plugins inside subdirectories with caching. To delete the cache: Visit the Must Use plugins list in the network administration.
  * Version:     1.3.0
  * Text Domain: must_use_loader
  * Author:      Frank Bültge


### PR DESCRIPTION
In the current state the plugin CANNOT be deployed via composer if you require stable packages (normal process) because the requirement is not stable.


move coding standards package to require-dev - fixes "unable to deploy stable" problem